### PR TITLE
bump bundler and initial update for net-http

### DIFF
--- a/lib/triplestore_adapter/providers/blazegraph.rb
+++ b/lib/triplestore_adapter/providers/blazegraph.rb
@@ -10,7 +10,7 @@ module TriplestoreAdapter::Providers
     ##
     # @param [String] url of SPARQL endpoint
     def initialize(url)
-      @http = Net::HTTP::Persistent.new(self.class)
+      @http = Net::HTTP::Persistent.new
       @url = url
       @uri = URI.parse(@url.to_s)
       @sparql_client = SPARQL::Client.new(@uri)
@@ -57,8 +57,7 @@ module TriplestoreAdapter::Providers
       raise(TriplestoreAdapter::TriplestoreException, "get_statements received blank subject") if subject.empty?
       subject = URI.escape(subject.to_s)
       uri = URI.parse(format("%{uri}?GETSTMTS&s=<%{subject}>&includeInferred=false", {uri: @uri, subject: subject}))
-      request = Net::HTTP::Get.new(uri)
-      response = @http.request(uri, request)
+      response = @http.request uri
       RDF::Reader.for(:ntriples).new(response.body)
     end
 

--- a/lib/triplestore_adapter/providers/blazegraph.rb
+++ b/lib/triplestore_adapter/providers/blazegraph.rb
@@ -57,7 +57,8 @@ module TriplestoreAdapter::Providers
       raise(TriplestoreAdapter::TriplestoreException, "get_statements received blank subject") if subject.empty?
       subject = URI.escape(subject.to_s)
       uri = URI.parse(format("%{uri}?GETSTMTS&s=<%{subject}>&includeInferred=false", {uri: @uri, subject: subject}))
-      response = @http.request uri
+      request = Net::HTTP::Get.new(uri)
+      response = @http.request(uri, request)
       RDF::Reader.for(:ntriples).new(response.body)
     end
 

--- a/triplestore-adapter.gemspec
+++ b/triplestore-adapter.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     "rdf"
   spec.add_runtime_dependency     "json-ld"
   spec.add_runtime_dependency     "rdf-rdfxml"
-  spec.add_runtime_dependency     "net-http-persistent", "~> 2.9"
+  spec.add_runtime_dependency     "net-http-persistent"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.10"


### PR DESCRIPTION
Currently trying to fix tests for fetching graphs and deleting graphs. Everything else seems to be working, but the updates to net-http-persistent are proving to have changed a bit about how the library works. 